### PR TITLE
Fixes targets normalization

### DIFF
--- a/src/CanonicalJsonTrait.php
+++ b/src/CanonicalJsonTrait.php
@@ -53,7 +53,7 @@ trait CanonicalJsonTrait
      * @throws \RuntimeException
      *     Thrown if sorting the array fails.
      */
-    private static function sortKeys(array &$data): void
+    protected static function sortKeys(array &$data): void
     {
         // If $data is numerically indexed, the keys are already sorted, by
         // definition.

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -52,19 +52,6 @@ abstract class MetadataBase
     }
 
     /**
-     * Returns a normalized array version of this object for JSON encoding.
-     *
-     * @see ::toCanonicalJson()
-     *
-     * @return array
-     *   A normalized array representation of this object.
-     */
-    protected function toNormalizedArray(): array
-    {
-        return $this->getSigned();
-    }
-
-    /**
      * Returns a canonical JSON representation of this metadata object.
      *
      * @return string
@@ -72,7 +59,7 @@ abstract class MetadataBase
      */
     public function toCanonicalJson(): string
     {
-        return static::encodeJson($this->toNormalizedArray());
+        return static::encodeJson($this->getSigned());
     }
 
     /**

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -66,27 +66,33 @@ class TargetsMetadata extends MetadataBase
     }
 
     /**
-     * {@inheritDoc}
+     * Returns a canonical JSON representation of this metadata object.
+     *
+     * @return string
+     *   The canonical JSON representation of this object.
      */
-    protected function toNormalizedArray(): array
+    public function toCanonicalJson(): string
     {
-        $normalized = parent::toNormalizedArray();
+        $metadata = $this->getSigned();
 
-        foreach ($normalized['targets'] as $path => $target) {
+        // Apply sorting
+        self::sortKeys($metadata);
+
+        foreach ($metadata['targets'] as $path => $target) {
             // Custom target info should always encode to an object, even if
             // it's empty.
             if (array_key_exists('custom', $target)) {
-                $normalized['targets'][$path]['custom'] = (object) $target['custom'];
+                $metadata['targets'][$path]['custom'] = (object) $target['custom'];
             }
         }
 
         // Ensure that these will encode as objects even if they're empty.
-        $normalized['targets'] = (object) $normalized['targets'];
-        if (array_key_exists('delegations', $normalized)) {
-            $normalized['delegations']['keys'] = (object) $normalized['delegations']['keys'];
+        $metadata['targets'] = (object) $metadata['targets'];
+        if (array_key_exists('delegations', $metadata)) {
+            $metadata['delegations']['keys'] = (object) $metadata['delegations']['keys'];
         }
 
-        return $normalized;
+        return static::encodeJson($metadata);
     }
 
     /**


### PR DESCRIPTION
We ran into an issue where php-tuf was unable to verify a signature of a valid targets metadata file.
After some closer investigation we realized that this was caused by a mismatch between the canonical JSON that is generated by php-tuf and the canonical JSON that the CLI tool generated for the signature.

The root cause for is the fact that "toNormalizedArray" in TargetsMetadata converted multiple properties from an array to object. Because of that, "sortKey" in the CanonicalJsonTrait did not correctly recurse into the sublevels, leaving array keys in sublevels unsorted. That leads to an invalid canonical JSON.

In this PR we removed the toNormalizedArray method and instead decided to override the toCanonicalJSON method. That also is a better fit for this specific usecase, as the casting to object isn't meant to normalize the array itself but specifically modifiy the generated JSON output.

Ref https://github.com/php-tuf/php-tuf/pull/348
