### PR TITLE
Recreate signature verifier while update root metadata

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -229,6 +229,10 @@ class Updater
             // § 5.3.7
             $rootData = $nextRoot;
 
+            // Recreate Verifier with new root metadata
+            $this->signatureVerifier = SignatureVerifier::createFromRootMetadata($rootData);
+            $this->universalVerifier = new UniversalVerifier($this->storage, $this->signatureVerifier, $this->metadataExpiration);
+
             // § 5.3.8
             $this->storage->save($nextRoot);
             // § 5.3.9: repeat from § 5.3.2.


### PR DESCRIPTION
Since the root metadata provides new signatures which could be needed while reading new root metadata entries, it's needed to recreate/update the SignatureVerifier and the universalVerifier while updating root metadata objects.