### PR TITLE
Dependency: Allowing 2.0 for guzzlehttp/promises

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/validator": "^4.4 || ^5 || ^6",
         "guzzlehttp/psr7": "^2.4",
         "symfony/polyfill-php81": "^1.27",
-        "guzzlehttp/promises": "^1.5"
+        "guzzlehttp/promises": "^1.5 || ^2.0"
     },
     "suggest": {
         "ext-sodium": "Provides faster verification of updates"


### PR DESCRIPTION
Unfortunately guzzlehttp/promises 1.5 is not compatible with PHP 8.4. This PR relaxes the requirements to also allow version 2.0. 2.0 seems to be fully compatible with 1.5 from our perspective.