### PR TITLE
Fix php 8.4 compat issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       max-parallel: 10
       matrix:
         operating-system: [ubuntu-latest, macos-latest, windows-latest]
-        php: ['8.0', '8.1', '8.2']
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
         # We need to use the ~ operator to prevent weirdness on Windows.
         # See https://github.com/composer/composer/issues/10943
         dependencies:

--- a/src/Client/Repository.php
+++ b/src/Client/Repository.php
@@ -80,7 +80,7 @@ class Repository
      * @return \Tuf\Metadata\SnapshotMetadata
      *   The untrusted snapshot metadata.
      */
-    public function getSnapshot(?int $version, int $maxBytes = null): SnapshotMetadata
+    public function getSnapshot(?int $version, ?int $maxBytes = null): SnapshotMetadata
     {
         $name = isset($version) ? "$version.snapshot" : 'snapshot';
         // If a maximum number of bytes was provided, we must download *exactly*
@@ -107,7 +107,7 @@ class Repository
      * @return \GuzzleHttp\Promise\PromiseInterface<\Tuf\Metadata\TargetsMetadata>
      *   A promise wrapping the untrusted targets metadata.
      */
-    public function getTargets(?int $version, string $role = 'targets', int $maxBytes = null): PromiseInterface
+    public function getTargets(?int $version, string $role = 'targets', ?int $maxBytes = null): PromiseInterface
     {
         $name = isset($version) ? "$version.$role" : $role;
         // If a maximum number of bytes was provided, we must download *exactly*

--- a/src/DelegatedRole.php
+++ b/src/DelegatedRole.php
@@ -39,7 +39,7 @@ class DelegatedRole extends Role
         parent::__construct($name, $threshold, $keyIds);
     }
 
-    public static function createFromMetadata(iterable $roleInfo, string $name = null): Role
+    public static function createFromMetadata(iterable $roleInfo, ?string $name = null): Role
     {
         $roleConstraints = static::getRoleConstraints();
         $roleConstraints->fields += [

--- a/src/Exception/Attack/InvalidHashException.php
+++ b/src/Exception/Attack/InvalidHashException.php
@@ -30,7 +30,7 @@ class InvalidHashException extends TufException
      * @param \Throwable|null $previous
      *   The previous exception, if any.
      */
-    public function __construct(private StreamInterface $stream, $message = "", $code = 0, \Throwable $previous = null)
+    public function __construct(private StreamInterface $stream, $message = "", $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/FormatException.php
+++ b/src/Exception/FormatException.php
@@ -19,7 +19,7 @@ class FormatException extends TufException
      * @param \Throwable|null $previous
      *     (optional) The previous exception, if any, for exception chaining.
      */
-    public function __construct(string $malformedValue, string $message = "", \Throwable $previous = null)
+    public function __construct(string $malformedValue, string $message = "", ?\Throwable $previous = null)
     {
         if (empty($message)) {
             $message = 'Bad format';

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -21,7 +21,7 @@ class NotFoundException extends TufException
      * @param \Throwable|null $previous
      *     (optional) The previous exception, if any, for exception chaining.
      */
-    public function __construct(string $key = '', string $itemType = 'Item', \Throwable $previous = null)
+    public function __construct(string $key = '', string $itemType = 'Item', ?\Throwable $previous = null)
     {
         $message = "$itemType not found";
         if ($key != "") {

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -36,7 +36,7 @@ class TargetsMetadata extends MetadataBase
      * @param string|null $roleName
      *   The role name if not the same as the type.
      */
-    public static function createFromJson(string $json, string $roleName = null): static
+    public static function createFromJson(string $json, ?string $roleName = null): static
     {
         $newMetadata = parent::createFromJson($json);
         $newMetadata->role = $roleName;

--- a/src/Metadata/Verifier/SnapshotVerifier.php
+++ b/src/Metadata/Verifier/SnapshotVerifier.php
@@ -26,7 +26,7 @@ class SnapshotVerifier extends FileInfoVerifier
      * @param \Tuf\Metadata\TimestampMetadata|null $timestampMetadata
      *   The trusted timestamp metadata, if there is any.
      */
-    public function __construct(SignatureVerifier $signatureVerifier, \DateTimeImmutable $metadataExpiration, MetadataBase $trustedMetadata = null, TimestampMetadata $timestampMetadata = null)
+    public function __construct(SignatureVerifier $signatureVerifier, \DateTimeImmutable $metadataExpiration, ?MetadataBase $trustedMetadata = null, ?TimestampMetadata $timestampMetadata = null)
     {
         parent::__construct($signatureVerifier, $metadataExpiration, $trustedMetadata);
         $this->setTrustedAuthority($timestampMetadata);

--- a/src/Metadata/Verifier/TargetsVerifier.php
+++ b/src/Metadata/Verifier/TargetsVerifier.php
@@ -25,7 +25,7 @@ class TargetsVerifier extends VerifierBase
      * @param SnapshotMetadata|null $snapshotMetadata
      *   The trusted snapshot metadata, if any.
      */
-    public function __construct(SignatureVerifier $signatureVerifier, \DateTimeImmutable $expiration, MetadataBase $trustedMetadata = null, SnapshotMetadata $snapshotMetadata = null)
+    public function __construct(SignatureVerifier $signatureVerifier, \DateTimeImmutable $expiration, ?MetadataBase $trustedMetadata = null, ?SnapshotMetadata $snapshotMetadata = null)
     {
         parent::__construct($signatureVerifier, $expiration, $trustedMetadata);
         $this->setTrustedAuthority($snapshotMetadata);


### PR DESCRIPTION
Fixes PHP 8.4 compat issues reported by @brianteeman

[19-Mar-2025 16:44:04 UTC] PHP Deprecated:  Tuf\Client\Repository::getSnapshot(): Implicitly marking parameter $maxBytes as nullable is deprecated, the explicit nullable type must be used instead in D:\repos\j51\libraries\vendor\php-tuf\php-tuf\src\Client\Repository.php on line 83
[19-Mar-2025 16:44:04 UTC] PHP Deprecated:  Tuf\Client\Repository::getTargets(): Implicitly marking parameter $maxBytes as nullable is deprecated, the explicit nullable type must be used instead in D:\repos\j51\libraries\vendor\php-tuf\php-tuf\src\Client\Repository.php on line 110